### PR TITLE
5 Lack of precision in integer truncation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tsastro/tsofa",
-    "version": "18.0.0",
+    "version": "18.1.0",
     "type": "module",
     "description": "a typescript transcription of the IAU SOFA library",
     "author": "Paul Harrison <paul.harrison@manchester.ac.uk>",

--- a/src/main/ts/TSOFA.ts
+++ b/src/main/ts/TSOFA.ts
@@ -1918,7 +1918,7 @@
             ly = ((im === 2) && (iy % 4 === 0) && (iy % 100 !== 0 || (iy % 400 === 0))) ? 1 : 0;
             if ((id < 1) || (id > (mtab[im - 1] + ly))){
             } //TODO compare to original
-            my = ((im - 14) / 12|0);
+            my = Math.trunc((im - 14) / 12);
             iypmy = (n => n<0?Math.ceil(n):Math.floor(n))(<number>(iy + my));
             djm0 = TSOFA.DJM0_$LI$();
             djm = <number>((n => n<0?Math.ceil(n):Math.floor(n))((1461 * (iypmy + 4800)) / 4) + (n => n<0?Math.ceil(n):Math.floor(n))((367 * (n => n<0?Math.ceil(n):Math.floor(n))(<number>(im - 2 - 12 * my))) / 12) - (n => n<0?Math.ceil(n):Math.floor(n))((3 * ((n => n<0?Math.ceil(n):Math.floor(n))((iypmy + 4900) / 100))) / 4) + (n => n<0?Math.ceil(n):Math.floor(n))(<number>id) - 2432076);
@@ -2108,10 +2108,10 @@
             as = a / rs;
             as = TSOFA.dint(as);
             af = a - as * rs;
-            ihmsf[0] = (<number>ah|0);
-            ihmsf[1] = (<number>am|0);
-            ihmsf[2] = (<number>as|0);
-            ihmsf[3] = (<number>af|0);
+            ihmsf[0] = Math.trunc(ah);
+            ihmsf[1] = Math.trunc(am);
+            ihmsf[2] = Math.trunc(as);
+            ihmsf[3] = Math.trunc(af);
             return sign;
         }
 
@@ -3711,12 +3711,12 @@
             const cs0: number[][] = [TSOFA.SSB.s0x_$LI$(), TSOFA.SSB.s0y_$LI$(), TSOFA.SSB.s0z_$LI$()];
             const cs1: number[][] = [TSOFA.SSB.s1x_$LI$(), TSOFA.SSB.s1y_$LI$(), TSOFA.SSB.s1z_$LI$()];
             const cs2: number[][] = [TSOFA.SSB.s2x_$LI$(), TSOFA.SSB.s2y_$LI$(), TSOFA.SSB.s2z_$LI$()];
-            const ne0: number[] = [(TSOFA.Ephemeris.e0x_$LI$().length / 3|0), (TSOFA.Ephemeris.e0y_$LI$().length / 3|0), (TSOFA.Ephemeris.e0z_$LI$().length / 3|0)];
-            const ne1: number[] = [(TSOFA.Ephemeris.e1x_$LI$().length / 3|0), (TSOFA.Ephemeris.e1y_$LI$().length / 3|0), (TSOFA.Ephemeris.e1z_$LI$().length / 3|0)];
-            const ne2: number[] = [(TSOFA.Ephemeris.e2x_$LI$().length / 3|0), (TSOFA.Ephemeris.e2y_$LI$().length / 3|0), (TSOFA.Ephemeris.e2z_$LI$().length / 3|0)];
-            const ns0: number[] = [(TSOFA.SSB.s0x_$LI$().length / 3|0), (TSOFA.SSB.s0y_$LI$().length / 3|0), (TSOFA.SSB.s0z_$LI$().length / 3|0)];
-            const ns1: number[] = [(TSOFA.SSB.s1x_$LI$().length / 3|0), (TSOFA.SSB.s1y_$LI$().length / 3|0), (TSOFA.SSB.s1z_$LI$().length / 3|0)];
-            const ns2: number[] = [(TSOFA.SSB.s2x_$LI$().length / 3|0), (TSOFA.SSB.s2y_$LI$().length / 3|0), (TSOFA.SSB.s2z_$LI$().length / 3|0)];
+            const ne0: number[] = [Math.trunc(TSOFA.Ephemeris.e0x_$LI$().length / 3), Math.trunc(TSOFA.Ephemeris.e0y_$LI$().length / 3), Math.trunc(TSOFA.Ephemeris.e0z_$LI$().length / 3)];
+            const ne1: number[] = [Math.trunc(TSOFA.Ephemeris.e1x_$LI$().length / 3), Math.trunc(TSOFA.Ephemeris.e1y_$LI$().length / 3), Math.trunc(TSOFA.Ephemeris.e1z_$LI$().length / 3)];
+            const ne2: number[] = [Math.trunc(TSOFA.Ephemeris.e2x_$LI$().length / 3), Math.trunc(TSOFA.Ephemeris.e2y_$LI$().length / 3), Math.trunc(TSOFA.Ephemeris.e2z_$LI$().length / 3)];
+            const ns0: number[] = [Math.trunc(TSOFA.SSB.s0x_$LI$().length / 3), Math.trunc(TSOFA.SSB.s0y_$LI$().length / 3), Math.trunc(TSOFA.SSB.s0z_$LI$().length / 3)];
+            const ns1: number[] = [Math.trunc(TSOFA.SSB.s1x_$LI$().length / 3), Math.trunc(TSOFA.SSB.s1y_$LI$().length / 3), Math.trunc(TSOFA.SSB.s1z_$LI$().length / 3)];
+            const ns2: number[] = [Math.trunc(TSOFA.SSB.s2x_$LI$().length / 3), Math.trunc(TSOFA.SSB.s2y_$LI$().length / 3), Math.trunc(TSOFA.SSB.s2z_$LI$().length / 3)];
             let nterms: number;
             let jstat: number;
             let i: number;
@@ -6402,10 +6402,10 @@
             i = (n => n<0?Math.ceil(n):Math.floor(n))((4000 * (l + 1)) / 1461001);
             l -= (n => n<0?Math.ceil(n):Math.floor(n))((1461 * i) / 4) - 31;
             k = (n => n<0?Math.ceil(n):Math.floor(n))((80 * l) / 2447);
-            const id: number = (<number>(l - (n => n<0?Math.ceil(n):Math.floor(n))((2447 * k) / 80))|0);
+            const id: number = Math.trunc((l - (n => n<0?Math.ceil(n):Math.floor(n))((2447 * k) / 80)));
             l = (n => n<0?Math.ceil(n):Math.floor(n))(k / 11);
-            const im: number = (<number>(k + 2 - 12 * l)|0);
-            const iy: number = (<number>(100 * (n - 49) + i + l)|0);
+            const im: number = Math.trunc((k + 2 - 12 * l));
+            const iy: number = Math.trunc((100 * (n - 49) + i + l));
             return new TSOFA.Calendar(iy, im, id, f);
         }
 
@@ -6530,7 +6530,7 @@
                 iymdf[0] = cal.iy;
                 iymdf[1] = cal.im;
                 iymdf[2] = cal.id;
-                iymdf[3] = (<number>TSOFA.dnint(cal.fd * denom)|0);
+                iymdf[3] = Math.trunc(TSOFA.dnint(cal.fd * denom));
             } catch(e) {
                 j = -1;
             }

--- a/src/test/ts/TSOFATest.spec.ts
+++ b/src/test/ts/TSOFATest.spec.ts
@@ -1805,7 +1805,7 @@ export class TSOFATest {
             for(let index = 0; index < vec2.length; index++) {
                 let d = vec2[index];
                 {
-                    console.info(d);
+                    //console.info(d);
                 }
             }
         }

--- a/src/test/ts/TSOFATest.spec.ts
+++ b/src/test/ts/TSOFATest.spec.ts
@@ -3,7 +3,6 @@ import { expect, test } from '@jest/globals';
 import {TSOFA} from "../../main/ts/TSOFA"
 import {TSOFAInternalError} from "../../main/ts/TSOFAInternalError";
 import {TSOFAIllegalParameter} from "../../main/ts/TSOFAIllegalParameter";
-import { TSOFAException } from '../../main/ts/TSOFAException';
 
 
 
@@ -87,12 +86,12 @@ test("t_a2af", () => {
 test("t_a2tf", () => {
             const ihmsf: number[] = [0, 0, 0, 0];
             let s: string;
-            s = TSOFA.jauA2tf(4, -3.01234, ihmsf);
+            s = TSOFA.jauA2tf(11, -3.01234, ihmsf);
             viv((s).charCodeAt(0), ('-').charCodeAt(0), "jauA2tf", "s");
             viv(ihmsf[0], 11, "jauA2tf", "0");
             viv(ihmsf[1], 30, "jauA2tf", "1");
             viv(ihmsf[2], 22, "jauA2tf", "2");
-            viv(ihmsf[3], 6484, "jauA2tf", "3");
+            viv(ihmsf[3], 64843002522, "jauA2tf", "3");
         });
 test("t_anp", () => {
             vvd(TSOFA.jauAnp(-0.1), 6.183185307179587, 1.0E-12, "jauAnp", "");
@@ -554,12 +553,12 @@ test("t_cr", () => {
 test("t_d2tf", () => {
             const ihmsf: number[] = [0, 0, 0, 0];
             let s: string;
-            s = TSOFA.jauD2tf(4, -0.987654321, ihmsf);
+            s = TSOFA.jauD2tf(9, -0.987654320601852, ihmsf);
             viv((s).charCodeAt(0), ('-').charCodeAt(0), "jauD2tf", "s");
             viv(ihmsf[0], 23, "jauD2tf", "0");
             viv(ihmsf[1], 42, "jauD2tf", "1");
             viv(ihmsf[2], 13, "jauD2tf", "2");
-            viv(ihmsf[3], 3333, "jauD2tf", "3");
+            viv(ihmsf[3], 333300000, "jauD2tf", "3");
         });
 test("t_dat", () => {
             let deltat: number;


### PR DESCRIPTION
This change replaces 27 cases of bitwise OR 0 { x = (n | 0) } with Math library truncatoin { Math.trunc(n) } to ensure the a 64bit int output rather than a 32bit int that the bitwise method causes.